### PR TITLE
feat: rules_oci support

### DIFF
--- a/k8s/resolve.sh.tpl
+++ b/k8s/resolve.sh.tpl
@@ -28,4 +28,4 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-%{resolver} %{resolver_args} %{stamp_args} --template %{yaml} --image_chroot=%{image_chroot} --substitutions=%{substitutions} %{images} $@
+%{resolver} %{resolver_args} %{stamp_args} --template %{yaml} --image_chroot=%{image_chroot} --substitutions=%{substitutions} %{docker_images} %{oci_images} $@


### PR DESCRIPTION
This commit adds oci_images as a new element on k8s resources. Labels should point to oci_image rules. The resolver will read the image digest from the index.json file of each oci_image and replace the image references in the yaml.

Limitations: currently only either oci images or docker images are supported. This is just an artificial limitation and could probably be removed.